### PR TITLE
Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 appdirs ~= 1.4.4
 babelfish ~= 0.6.0
-guessit ~= 3.7.1
+guessit ~= 3.8.0
 requests == 2.*
 requests_cache ~= 0.9.7
 setuptools_scm ~= 7.1.0


### PR DESCRIPTION
We need guessit 3.8.0 for Python 3.13 compatibility.